### PR TITLE
added additional config accessors and added `RunMode.envPath`

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/config/AppName.scala
+++ b/src/main/scala/uk/gov/hmrc/play/config/AppName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/config/ControllerConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/play/config/ControllerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/config/ServicesConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/play/config/ServicesConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,4 +66,10 @@ trait ServicesConfig extends RunMode {
       getOrElse(Play.configuration.getBoolean(s"$playServices.$confKey").
       getOrElse(defBool)))
   }
+
+  def getInt(key: String) = Play.configuration.getInt(key).getOrElse(throw new RuntimeException(s"Could not find config key '$key'"))
+
+  def getString(key: String) = Play.configuration.getString(key).getOrElse(throw new RuntimeException(s"Could not find config key '$key'"))
+
+  def getBoolean(key: String) = Play.configuration.getBoolean(key).getOrElse(throw new RuntimeException(s"Could not find config key '$key'"))
 }

--- a/src/test/scala/uk/gov/hmrc/play/config/ControllerConfigTest.scala
+++ b/src/test/scala/uk/gov/hmrc/play/config/ControllerConfigTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/config/RunModeSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/config/RunModeSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.config
+
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import play.api.Play
+import play.api.test.FakeApplication
+
+class RunModeSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
+
+  lazy val fakeApplication = FakeApplication()
+
+  override def beforeAll() {
+    Play.start(fakeApplication)
+  }
+
+  override def afterAll() {
+    Play.stop()
+  }
+
+  trait Setup extends RunMode
+
+  "envPath" should {
+
+    "return the `other` env path" in new Setup {
+      override lazy val env = "Dev"
+
+      envPath("/somePath")(other = "http://localhost") shouldBe "http://localhost/somePath"
+      envPath("/somePath")(other = "http://localhost/") shouldBe "http://localhost/somePath"
+      envPath("//somePath")(other = "http://localhost") shouldBe "http://localhost/somePath"
+      envPath("somePath")(other = "http://localhost") shouldBe "http://localhost/somePath"
+      envPath("somePath")(other = "http://localhost/") shouldBe "http://localhost/somePath"
+      envPath("somePath/")(other = "http://localhost/") shouldBe "http://localhost/somePath"
+      envPath()(other = "http://localhost") shouldBe "http://localhost"
+    }
+
+    "return the `prod` env path" in new Setup {
+      override lazy val env = "Prod"
+
+      envPath("/somePath")(prod = "prod") shouldBe "/prod/somePath"
+      envPath("/somePath")(prod = "/prod") shouldBe "/prod/somePath"
+      envPath("/somePath")(prod = "//prod") shouldBe "/prod/somePath"
+      envPath("/somePath")(prod = "prod/") shouldBe "/prod/somePath"
+      envPath("/somePath")(prod = "/prod/") shouldBe "/prod/somePath"
+      envPath("/somePath")(prod = "//prod/") shouldBe "/prod/somePath"
+      envPath("//somePath")(prod = "/prod/") shouldBe "/prod/somePath"
+      envPath("somePath/")(prod = "prod") shouldBe "/prod/somePath"
+      envPath()(prod = "prod") shouldBe "/prod"
+    }
+
+  }
+}


### PR DESCRIPTION
- the new config accessors have no default, but throw expections when not found (fail fast)
- `envPath` helps build a url based on the `env`
